### PR TITLE
Add minus sign to event_start_idx in atsc.counting.data line 240

### DIFF
--- a/atsc/counting/data.py
+++ b/atsc/counting/data.py
@@ -237,7 +237,7 @@ class SyntheticTrafficDataset(Dataset):
 
             if event_start_idx < 0:
                 # Event starts before the beginning of the segment
-                event_audio = event_audio[:, event_start_idx:]
+                event_audio = event_audio[:, -event_start_idx:]
                 audio_segment[:, : event_audio.shape[-1]] += event_audio
             elif event_start_idx + event_audio.shape[-1] > audio_segment.shape[-1]:
                 # Event ends after the end of the segment


### PR DESCRIPTION
Bug fix in synthetic dataset: when creating synthetic segments in atsc.counting.data, a minus sign was missing in line 240, causing the wrong part of the simulated to be selected and added to the audio segment that is being generated